### PR TITLE
Fix: Trim white spaces in user provided shard-ids

### DIFF
--- a/options.go
+++ b/options.go
@@ -79,5 +79,9 @@ func (o *options) shardIDs() []string {
 	if o.sids == "" {
 		return make([]string, 0)
 	}
-	return strings.Split(o.sids, ",")
+	r := strings.Split(o.sids, ",")
+	for i, s := range r {
+		r[i] = strings.TrimSpace(s)
+	}
+	return r
 }


### PR DESCRIPTION
When specifying a list of shard ids, users are
likely to use white space characters.
This change will sanitise the input before passing it to sdk calls.
