### PR TITLE
docs: fix the getting started command and usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+
 	"github.com/awslabs/kinesis-hot-shard-advisor/analyse"
 	"github.com/awslabs/kinesis-hot-shard-advisor/analyse/aggregator"
 	"github.com/awslabs/kinesis-hot-shard-advisor/analyse/service"
@@ -27,8 +28,8 @@ func init() {
 	flag.StringVar(&opts.Stream, "stream", "", "Stream name")
 	flag.IntVar(&opts.Limit, "limit", 10, "Number of keys to output in key distribution graph (Optional).")
 	flag.BoolVar(&opts.CMS, "cms", true, "Use count-min-sketch (Optional) algorithm for counting key distribution (Optional). Default is false. Use this method to avoid OOM condition when analysing busy streams with high cardinality.")
-	flag.StringVar(&opts.Start, "from", "", "Start time in yyyy-mm-dd hh:mm format (Optional). Default value is current time - 5 minutes.")
-	flag.StringVar(&opts.End, "to", "", "End time in yyyy-mm-dd hh:mm format (Optional). Default value is current time.")
+	flag.StringVar(&opts.Start, "from", "", "Start time in yyyy-mm-dd hh:mm:ss format (Optional). Default value is current time - 5 minutes.")
+	flag.StringVar(&opts.End, "to", "", "End time in yyyy-mm-dd hh:mm:ss format (Optional). Default value is current time.")
 	flag.StringVar(&opts.Out, "out", "out.html", "Path to output file (Optional). Default is out.html.")
 	flag.StringVar(&opts.SIDs, "shard-ids", "", "Comma separated list of shard ids to analyse.")
 	flag.IntVar(&opts.Top, "top", 10, "Number of shards to emit to the report(Optional). Use 0 to emit all shards. Emitting all shards can result in a large file that may take a lot of system resources to view in the browser.")

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ kinesis:DescribeStreamConsumer
 3. run the below command
 ```
 khs -stream=[YOUR STREAM NAME]] -from="yyyy-mm-dd hh:mm" -to="yyyy-mm-dd hh:mm"
-Example:  khs -stream=lab3 -from="2022-02-24 10:07" -to="2022-02-24 10:09" 
+Example:  khs -stream=lab3 -from="2022-02-24 10:07:00" -to="2022-02-24 10:09:00" 
 Note: The date range should be within the retention period of your Kinesis data streams.
 ```
 ## Output sample
@@ -53,7 +53,7 @@ Once you see the output as above, open the file pointed by `out` option (by defa
   -cms
     	Use count-min-sketch (Optional) algorithm for counting key distribution (Optional). Default is false. Use this method to avoid OOM condition when analysing busy streams with high cardinality.
   -from string
-    	Start time in yyyy-mm-dd hh:mm format (Optional). Default value is current time - 5 minutes.
+    	Start time in yyyy-mm-dd hh:mm:ss format (Optional). Default value is current time - 5 minutes.
   -limit int
     	Number of keys to output in key distribution graph (Optional). (default 10)
   -out string
@@ -63,7 +63,7 @@ Once you see the output as above, open the file pointed by `out` option (by defa
   -stream string
     	Stream name
   -to string
-    	End time in yyyy-mm-dd hh:mm format (Optional). Default value is current time.
+    	End time in yyyy-mm-dd hh:mm:ss format (Optional). Default value is current time.
   -top int
     	Number of shards to emit to the report(Optional). Use 0 to emit all shards. Emitting all shards can result in a large file that may take a lot of system resources to view in the browser. (default 10)
 ```


### PR DESCRIPTION
Apparently, the docs area  bit outdated, as the new time format requires the seconds also when specifying the `from` and `to` options.

<img width="767" alt="Screenshot 2025-05-22 at 11 52 34" src="https://github.com/user-attachments/assets/823cbc61-e875-43d0-8c54-b7c9b2b587a7" />
